### PR TITLE
NEUT-14 array values need to be between -1 and 1

### DIFF
--- a/launcher/stitch_images.py
+++ b/launcher/stitch_images.py
@@ -285,6 +285,7 @@ class ImageStitcher:
                 rescale_intensity=False,
                 padding_width=10,
             )
+            sample_montage = np.clip(sample_montage, -1, 1)
             sample_montage = skimage.img_as_ubyte(sample_montage)
             well_path = os.path.join(self.output_dir_path, f"well_{well}.png")
             skimage.io.imsave(fname=well_path, arr=sample_montage)
@@ -310,6 +311,7 @@ class ImageStitcher:
             raise RuntimeError("no plate images, have you run stitch_plate()?")
         for channel_num, plate_arr in self.plate_images.items():
             plate_path = os.path.join(self.output_dir_path, f"plate_{channel_num}.png")
+            plate_arr = np.clip(plate_arr, -1, 1)
             plate_arr = skimage.img_as_ubyte(plate_arr)
             skimage.io.imsave(fname=plate_path, arr=plate_arr)
 


### PR DESCRIPTION
```python-traceback
Traceback (most recent call last):
  File "/home/warchas/miniconda3/lib/python3.8/site-packages/celery/app/trace.py", line 450, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/home/warchas/miniconda3/lib/python3.8/site-packages/celery/app/trace.py", line 731, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/warchas/miniconda3/lib/python3.8/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/home/warchas/launcher/launcher/task.py", line 175, in background_image_stitch_384
    stitcher.stitch_and_save_all_samples_and_plates()
  File "/home/warchas/launcher/launcher/stitch_images.py", line 310, in stitch_and_save_all_samples_and_plates
    self.stitch_and_save_samples()
  File "/home/warchas/launcher/launcher/stitch_images.py", line 294, in stitch_and_save_samples
    sample_montage = skimage.img_as_ubyte(sample_montage)
  File "/home/warchas/miniconda3/lib/python3.8/site-packages/skimage/util/dtype.py", line 531, in img_as_ubyte
    return _convert(image, np.uint8, force_copy)
  File "/home/warchas/miniconda3/lib/python3.8/site-packages/skimage/util/dtype.py", line 283, in _convert
    raise ValueError("Images of type float must be between -1 and 1.")
ValueError: Images of type float must be between -1 and 1.
```